### PR TITLE
docs: Fix a few typos

### DIFF
--- a/paython/gateways/core.py
+++ b/paython/gateways/core.py
@@ -102,7 +102,7 @@ class Gateway(object):
     def standardize(self, spec_response, field_mapping, response_time, approved):
         """
         Translates gateway specific response into Paython generic response.
-        Expects list or dictionary for spec_repsonse & dictionary for field_mapping.
+        Expects list or dictionary for spec_response & dictionary for field_mapping.
         """
         # manual settings
         self.RESPONSE_FIELDS['response_time'] = response_time

--- a/paython/gateways/firstdata.py
+++ b/paython/gateways/firstdata.py
@@ -235,7 +235,7 @@ class FirstData(PostGateway):
             logger.debug(response)
         if type(self._retry_on_bmc) is int and 0 < self._retry_on_bmc < 4 and response == "Unauthorized Request. Bad or missing credentials.":
             """When FDs servers return "Unauthorized Request. Bad or missing credentials."
-            which happend quite often for ABSOLUTLY no reason. We will try the request again.
+            which happened quite often for ABSOLUTLY no reason. We will try the request again.
             3 attempts will be made if this error occurs.
             I have contacted their support about this issue...sometime ago.
             """

--- a/paython/gateways/firstdata_legacy.py
+++ b/paython/gateways/firstdata_legacy.py
@@ -221,7 +221,7 @@ class FirstDataLegacy(XMLGateway):
     def void(self, trans_id):
         """
         Send a SALE (only works for sales) transaction to be voided (in full) that was initially sent for capture the same day
-        This is so wierd!
+        This is so weird!
         """
         #set up transaction
         self.charge_setup() # considering turning this into a decorator?

--- a/paython/gateways/plugnpay.py
+++ b/paython/gateways/plugnpay.py
@@ -363,7 +363,7 @@ class PlugnPay(PostGateway):
         if password: # optional gateway password
             super(PlugnPay, self).set('publisher-password', password)
 
-        if email: # publisher email to send alerts/notifiation to
+        if email: # publisher email to send alerts/notification to
             super(PlugnPay, self).set('publisher-email', email)
 
         # don't send transaction confirmation email to customer


### PR DESCRIPTION
There are small typos in:
- paython/gateways/core.py
- paython/gateways/firstdata.py
- paython/gateways/firstdata_legacy.py
- paython/gateways/plugnpay.py

Fixes:
- Should read `weird` rather than `wierd`.
- Should read `response` rather than `repsonse`.
- Should read `notification` rather than `notifiation`.
- Should read `happened` rather than `happend`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md